### PR TITLE
Add systemd service file

### DIFF
--- a/ipman.service
+++ b/ipman.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Enable Lenovo Ideapad battery protection
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ipman -e
+ExecStop=/usr/bin/ipman -d
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+

--- a/ipman.service
+++ b/ipman.service
@@ -6,7 +6,8 @@ Type=oneshot
 ExecStart=/usr/bin/ipman -e
 ExecStop=/usr/bin/ipman -d
 RemainAfterExit=yes
+Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Add a systemd service file to enable battery protection.
I find this useful since it can easily be enabled to run on boot. Previously I've had trouble with it being randomly disabled (maybe after battery is fully depleted?).
The systemd service is pretty basic, allowing systemctl start/stop commands to enable/disable the battery mode.